### PR TITLE
Develop

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,11 +11,11 @@ pipeline {
     }
 
     stages {
-        stage('Checkout') {
+        /*stage('Checkout') {
             steps {
                 git branch: 'develop', url: 'https://github.com/JavierAntunezE/Selenium-avanzado.git'
             }
-        }
+        }*/
 
         stage('Build') {
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                git 'https://github.com/JavierAntunezE/Selenium-avanzado.git'
+                git branch: 'develop', url: 'https://github.com/JavierAntunezE/Selenium-avanzado.git'
             }
         }
 


### PR DESCRIPTION
Deshabilita el stage 'Checkout' ya que esto se configura directamente en Jenkins
Puede ser util solo si necesitas:

- Cambiar de rama.
- Clonar otro repo.
- Trabajar en un subdirectorio diferente.
- Forzar un nuevo checkout por alguna razón específica.